### PR TITLE
feat: add spec-kit CLI to base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,12 +45,15 @@ ARG GITHUB_COPILOT_VERSION=0.0.410
 ARG GEMINI_CLI_VERSION=0.28.2
 # renovate: datasource=npm depName=@openai/codex
 ARG OPENAI_CODEX_VERSION=0.101.0
+# renovate: datasource=npm depName=@spec-kit/cli
+ARG SPEC_KIT_CLI_VERSION=0.3.1
 
 RUN npm install -g \
     @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
     @github/copilot@${GITHUB_COPILOT_VERSION} \
     @google/gemini-cli@${GEMINI_CLI_VERSION} \
     @openai/codex@${OPENAI_CODEX_VERSION} \
+    @spec-kit/cli@${SPEC_KIT_CLI_VERSION} \
     && npm cache clean --force
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
             echo 'Checking codex...'
             codex --version
             
+            echo 'Checking speckit...'
+            speckit --version
+            
             echo 'Checking opencode...'
             opencode --version
             


### PR DESCRIPTION
## Summary
- Add `@spec-kit/cli` to the npm global install step in the Dockerfile
- Follows the existing pattern for other AI/agent CLI tools (Claude Code, Gemini CLI, Codex)
- spec-kit CLI was already listed as planned tooling in the README

## Test plan
- [ ] `docker build` succeeds with the updated Dockerfile
- [ ] `speckit --version` runs inside the built container

🤖 Generated with [Claude Code](https://claude.com/claude-code)