### PR TITLE
refactor(dockerfile): consolidate all ARG declarations into a single top-level section

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,9 +11,27 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ---------------------------------------------------------------------------
-# Node.js (LTS) via NodeSource
+# Version ARGs — edit here to update tool versions
 # ---------------------------------------------------------------------------
 ARG NODE_VERSION=22
+# renovate: datasource=npm depName=@anthropic-ai/claude-code
+ARG CLAUDE_CODE_VERSION=2.1.63
+# renovate: datasource=npm depName=@github/copilot
+ARG GITHUB_COPILOT_VERSION=0.0.420
+# renovate: datasource=npm depName=@google/gemini-cli
+ARG GEMINI_CLI_VERSION=0.31.0
+# renovate: datasource=npm depName=@openai/codex
+ARG OPENAI_CODEX_VERSION=0.107.0
+# renovate: datasource=npm depName=opencode-ai
+ARG OPENCODE_VERSION=1.2.15
+# renovate: datasource=npm depName=@sourcegraph/amp
+ARG AMP_VERSION=0.0.1772481904-gb6b1d9
+# renovate: datasource=npm depName=vibe-kanban
+ARG VIBE_KANBAN_VERSION=0.1.22
+
+# ---------------------------------------------------------------------------
+# Node.js (LTS) via NodeSource
+# ---------------------------------------------------------------------------
 # hadolint ignore=DL3008
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
@@ -37,21 +55,6 @@ RUN mkdir -p /etc/apt/keyrings \
 # ---------------------------------------------------------------------------
 # AI / Agent CLI tools (npm global installs)
 # ---------------------------------------------------------------------------
-# renovate: datasource=npm depName=@anthropic-ai/claude-code
-ARG CLAUDE_CODE_VERSION=2.1.63
-# renovate: datasource=npm depName=@github/copilot
-ARG GITHUB_COPILOT_VERSION=0.0.420
-# renovate: datasource=npm depName=@google/gemini-cli
-ARG GEMINI_CLI_VERSION=0.31.0
-# renovate: datasource=npm depName=@openai/codex
-ARG OPENAI_CODEX_VERSION=0.107.0
-# renovate: datasource=npm depName=opencode-ai
-ARG OPENCODE_VERSION=1.2.15
-# renovate: datasource=npm depName=@sourcegraph/amp
-ARG AMP_VERSION=0.0.1772481904-gb6b1d9
-# renovate: datasource=npm depName=vibe-kanban
-ARG VIBE_KANBAN_VERSION=0.1.22
-
 RUN npm install -g \
     @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
     @github/copilot@${GITHUB_COPILOT_VERSION} \


### PR DESCRIPTION
## Summary

- Moves all version `ARG` declarations from their individual tool sections to a single **Version ARGs** block near the top of the Dockerfile
- Keeps `# renovate:` comments attached to each `ARG` so Renovate continues to manage version updates automatically
- No functional changes — all `ARG` values and `RUN` commands are unchanged

Closes #21

## Test plan

- [ ] Verify Dockerfile builds successfully
- [ ] Confirm all tool versions remain the same
- [ ] Confirm Renovate regex manager still picks up ARG updates (comments preserved on the line immediately before each ARG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)