### PR TITLE
feat(tools): pin gh CLI version and enable Renovate updates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
 # ---------------------------------------------------------------------------
 # GitHub CLI
 # ---------------------------------------------------------------------------
+# renovate: datasource=github-releases depName=cli/cli
+ARG GH_VERSION=2.87.3
 # hadolint ignore=DL3008
 RUN mkdir -p /etc/apt/keyrings \
     && chmod 755 /etc/apt/keyrings \
@@ -31,7 +33,7 @@ RUN mkdir -p /etc/apt/keyrings \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     | tee /etc/apt/sources.list.d/github-cli.list >/dev/null \
     && apt-get update \
-    && apt-get install -y --no-install-recommends gh \
+    && apt-get install -y --no-install-recommends "gh=${GH_VERSION}" \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `ARG GH_VERSION=2.87.3` with a `# renovate: datasource=github-releases depName=cli/cli` comment to the Dockerfile
- Pin the apt install to `gh=${GH_VERSION}` so the version is explicit and reproducible
- Renovate will automatically open PRs to keep the version current, consistent with other CLI tools

Closes #22

## Test plan

- [x] CI build passes (Docker image builds successfully with pinned `gh` version)
- [x] Smoke test confirms `gh --version` outputs the expected version
- [x] Renovate regex manager picks up the new `GH_VERSION` ARG (verify via Renovate dry-run or dependency dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)